### PR TITLE
Fixes #3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gulp-install": "latest",
     "gulp-rename": "latest",
     "gulp-template": "latest",
+    "gulp-if": "latest",
     "inquirer": "latest",
     "underscore.string": "latest"
   },

--- a/slushfile.js
+++ b/slushfile.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp'),
     conflict = require('gulp-conflict'),
     install = require('gulp-install'),
+    gulpif = require('gulp-if'),
     inquirer = require('inquirer'),
     path = require('path'),
     template = require('gulp-template'),
@@ -20,7 +21,7 @@ gulp.task('default', function (cb) {
     answers.camel = _.camelize(answers.slug);
     path.resolve(process.cwd(), answers.slug);
     gulp.src(__dirname + '/templates/typescript/**')
-      .pipe(template(answers))
+      .pipe(gulpif(/^(?!.*angular2\.d\.ts$)/, template(answers)))
       .pipe(conflict(path.join(process.cwd(), answers.slug)))
       .pipe(gulp.dest(path.join(process.cwd(), answers.slug)))
       .pipe(install())


### PR DESCRIPTION
You can't template angular2.d.ts since it has a lot of doc comments with handlebars statements like `{{ value }}`. lodash doesn't like templates to not resolve all substitutions, thus the ReferenceError.
